### PR TITLE
Update ocserv-country-blocking.md

### DIFF
--- a/ocserv-country-blocking.md
+++ b/ocserv-country-blocking.md
@@ -23,7 +23,7 @@ if [ "x${IP_REAL}" = "x" ]; then
   exit 1
 fi
 
-GEOIP_STRING=$(/bin/curl -s https://freegeoip.net/csv/$IP_REAL)
+GEOIP_STRING=$(curl -s https://freegeoip.live/csv/$IP_REAL)
 # Alternatively, in Fedora 23 or higher, the following would also provide the 
 # country code variable using the local geoip database:
 # COUNTRY_CODE=$(ipcalc -g ${IP_REAL} | grep CODE | cut -d'=' -f2)


### PR DESCRIPTION
Refer to https://github.com/openconnect/recipes/issues/9

Updated the GeoIP URL to  freegeoip.live

removed /bin in front of curl to make script use system path (not all Linux systems have curl located at /bin)